### PR TITLE
Issue 1: micro/kernel-app uses micro/plugin-event-emitter but does not require it in composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,8 @@
         }
     ],
     "require": {
-        "micro/kernel": "^0.1"
+        "micro/kernel": "^0.1",
+        "micro/plugin-event-emitter": "^0.1",
+        "micro/dependency-injection": "^0.1"
     }
 }


### PR DESCRIPTION
- Added `micro/plugin-event-emitter` and `micro/dependency-injection` to `composer.json` file;